### PR TITLE
wrapped HANAmasterPass in single quotes.

### DIFF
--- a/templates/SAP-HANA-BaseNodes.template
+++ b/templates/SAP-HANA-BaseNodes.template
@@ -2658,11 +2658,11 @@
                                 {
                                     "Ref": "SAPInstanceNum"
                                 },
-                                " -p ",
+                                " -p '",
                                 {
                                     "Ref": "HANAMasterPass"
                                 },
-                                " -n ",
+                                "' -n ",
                                 {
                                     "Ref": "HANAMasterHostname"
                                 },


### PR DESCRIPTION
If the password provided contains ) this is interpreted as JSON and the validation fails.

After adding the single quotes the value provided in the HANAMasterPASS parameter is treated as a literal value and not passed as a JSON.