### PR TITLE
Support for R5b and new IAM polocies

### DIFF
--- a/scripts/create-attach-single-volume.sh
+++ b/scripts/create-attach-single-volume.sh
@@ -217,13 +217,18 @@ then
 					--region ${AWS_DEFAULT_REGION} \
 					--availability-zone ${AWS_DEFAULT_AVAILABILITY_ZONE} \
 					--size ${VOL_SIZE} \
-					--volume-type ${VOL_TYPE} --iops ${VOL_PIOPS} | ${JQ_COMMAND} '.VolumeId')
+					--volume-type ${VOL_TYPE} --iops ${VOL_PIOPS} \
+					--tag-specification ResourceType=volume,Tags=[\{Key=SAPHANAQuickStart,Value=${MyStackId}\}] \
+					| ${JQ_COMMAND} '.VolumeId' )
+					
 	else
 		volumeid=$(${AWS} ec2 create-volume \
 					--region ${AWS_DEFAULT_REGION} \
 					--availability-zone ${AWS_DEFAULT_AVAILABILITY_ZONE} \
 					--size ${VOL_SIZE} \
-					--volume-type ${VOL_TYPE}| ${JQ_COMMAND} '.VolumeId')
+					--volume-type ${VOL_TYPE} \
+					--tag-specification ResourceType=volume,Tags=[\{Key=SAPHANAQuickStart,Value=${MyStackId}\}] \
+					| ${JQ_COMMAND} '.VolumeId')
 	fi
 else
 	if [[ "${VOL_TYPE}" == "io1" || "${VOL_TYPE}" == "io2" ]]; then
@@ -231,13 +236,17 @@ else
 					--region ${AWS_DEFAULT_REGION} \
 					--availability-zone ${AWS_DEFAULT_AVAILABILITY_ZONE} --encrypted \
 					--size ${VOL_SIZE} \
-					--volume-type ${VOL_TYPE} --iops ${VOL_PIOPS} | ${JQ_COMMAND} '.VolumeId')
+					--volume-type ${VOL_TYPE} --iops ${VOL_PIOPS} \
+					--tag-specification ResourceType=volume,Tags=[\{Key=SAPHANAQuickStart,Value=${MyStackId}\}] \
+					| ${JQ_COMMAND} '.VolumeId')
 	else
 		volumeid=$(${AWS} ec2 create-volume \
 					--region ${AWS_DEFAULT_REGION} \
 					--availability-zone ${AWS_DEFAULT_AVAILABILITY_ZONE} --encrypted \
 					--size ${VOL_SIZE} \
-					--volume-type ${VOL_TYPE}| ${JQ_COMMAND} '.VolumeId')
+					--volume-type ${VOL_TYPE}\
+					--tag-specification ResourceType=volume,Tags=[\{Key=SAPHANAQuickStart,Value=${MyStackId}\}] \
+					| ${JQ_COMMAND} '.VolumeId')
 	fi
 fi
 

--- a/scripts/create-attach-volume.sh
+++ b/scripts/create-attach-volume.sh
@@ -176,13 +176,17 @@ while [  $COUNTER -lt ${VOL_COUNT} ]; do
 					--region ${AWS_DEFAULT_REGION} \
 					--availability-zone ${AWS_DEFAULT_AVAILABILITY_ZONE} \
 					--size ${VOL_SIZE} \
-					--volume-type ${VOL_TYPE} --iops ${VOL_PIOPS} | ${JQ_COMMAND} '.VolumeId')
+					--volume-type ${VOL_TYPE} --iops ${VOL_PIOPS} \
+					--tag-specification ResourceType=volume,Tags=[\{Key=SAPHANAQuickStart,Value=${MyStackId}\}] \
+					| ${JQ_COMMAND} '.VolumeId')
 	else
 		volumeid=$(aws ec2 create-volume \
 					--region ${AWS_DEFAULT_REGION} \
 					--availability-zone ${AWS_DEFAULT_AVAILABILITY_ZONE} \
 					--size ${VOL_SIZE} \
-					--volume-type ${VOL_TYPE}| ${JQ_COMMAND} '.VolumeId')
+					--volume-type ${VOL_TYPE} \
+					--tag-specification ResourceType=volume,Tags=[\{Key=SAPHANAQuickStart,Value=${MyStackId}\}] \
+					| ${JQ_COMMAND} '.VolumeId')
 	fi
 	volumeid=$(echo ${volumeid} | sed 's/^"\(.*\)"$/\1/')
 	log "Creating new volume ${volumeid}. Waiting for create"

--- a/scripts/install-prereq-sles.sh
+++ b/scripts/install-prereq-sles.sh
@@ -1268,17 +1268,17 @@ start_oss_configs() {
     
      
     case $instance_type in
-      r4.8xlarge|r4.16xlarge|x1.16xlarge|x1.32xlarge|x1e.32xlarge|r5.metal|u-6tb1.metal|u-9tb1.metal|u-12tb1.metal )
+      r4.8xlarge|r4.16xlarge|x1.16xlarge|x1.32xlarge|x1e.32xlarge|r5.metal|r5b.metal|u-6tb1.metal|u-9tb1.metal|u-12tb1.metal )
           log "`date` Configuring c-state"
           cpupower frequency-set -g performance > /dev/null
-          # cpupower idle-set -d 6 > /dev/null; cpupower idle-set -d 5 > /dev/null
-          # cpupower idle-set -d 4 > /dev/null; cpupower idle-set -d 3 > /dev/null
-          # cpupower idle-set -d 2 > /dev/null
-	        echo "cpupower frequency-set -g performance" >> /etc/init.d/boot.local
+          cpupower idle-set -d 6 > /dev/null; cpupower idle-set -d 5 > /dev/null
+          cpupower idle-set -d 4 > /dev/null; cpupower idle-set -d 3 > /dev/null
+          cpupower idle-set -d 2 > /dev/null
+          echo "cpupower frequency-set -g performance" >> /etc/init.d/boot.local
           # echo "cpupower idle-set -d 6 > /dev/null; cpupower idle-set -d 5 > /dev/null" >> /etc/init.d/boot.local
-     	    # echo "cpupower idle-set -d 4 > /dev/null; cpupower idle-set -d 3 > /dev/null" >> /etc/init.d/boot.local
-     	    # echo "cpupower idle-set -d 2 > /dev/null" >> /etc/init.d/boot.local
-     	    ;;
+     	  # echo "cpupower idle-set -d 4 > /dev/null; cpupower idle-set -d 3 > /dev/null" >> /etc/init.d/boot.local
+     	  # echo "cpupower idle-set -d 2 > /dev/null" >> /etc/init.d/boot.local
+     	  ;;
       *)
           log "`date`  Instance type doesn't allow c-state and p-state configuration" ;;
     esac

--- a/scripts/storage.json
+++ b/scripts/storage.json
@@ -561,7 +561,162 @@
                 }
               ]
             }
+          },
+          "r5b.2xlarge": {
+            "gp2": {
+              "drives": [
+                {
+                  "device": "/dev/sdf",
+                  "size": "256G"
+                },
+                {
+                  "device": "/dev/sdg",
+                  "size": "256G"
+                }
+              ]
+            },
+            "st1": {
+              "drives": [
+                {
+                  "device": "/dev/sdf",
+                  "size": "512G"
+                }
+              ]
+            }
+          },
+          "r5b.4xlarge": {
+            "gp2": {
+              "drives": [
+                {
+                  "device": "/dev/sdf",
+                  "size": "2566G"
+                },
+                {
+                  "device": "/dev/sdg",
+                  "size": "256G"
+                }
+              ]
+            },
+            "st1": {
+              "drives": [
+                {
+                  "device": "/dev/sdf",
+                  "size": "512G"
+                }
+              ]
+            }
+          },
+          "r5b.8xlarge": {
+            "gp2": {
+              "drives": [
+                {
+                  "device": "/dev/sdf",
+                  "size": "512G"
+                },
+                {
+                  "device": "/dev/sdg",
+                  "size": "512G"
+                }
+              ]
+            },
+            "st1": {
+              "drives": [
+                {
+                  "device": "/dev/sdf",
+                  "size": "1024G"
+                }
+              ]
+            }
+          },
+          "r5b.12xlarge": {
+            "gp2": {
+              "drives": [
+                {
+                  "device": "/dev/sdf",
+                  "size": "512G"
+                },
+                {
+                  "device": "/dev/sdg",
+                  "size": "512G"
+                }
+              ]
+            },
+            "st1": {
+              "drives": [
+                {
+                  "device": "/dev/sdf",
+                  "size": "1024G"
+                }
+              ]
+            }
+          },
+          "r5b.16xlarge": {
+            "gp2": {
+              "drives": [
+                {
+                  "device": "/dev/sdf",
+                  "size": "512G"
+                },
+                {
+                  "device": "/dev/sdg",
+                  "size": "512G"
+                }
+              ]
+            },
+            "st1": {
+              "drives": [
+                {
+                  "device": "/dev/sdf",
+                  "size": "1024G"
+                }
+              ]
+            }
+          },
+          "r5b.24xlarge": {
+            "gp2": {
+              "drives": [
+                {
+                  "device": "/dev/sdf",
+                  "size": "1024G"
+                },
+                {
+                  "device": "/dev/sdg",
+                  "size": "1024G"
+                }
+              ]
+            },
+            "st1": {
+              "drives": [
+                {
+                  "device": "/dev/sdf",
+                  "size": "2048G"
+                }
+              ]
+            }
+          },
+          "r5b.metal": {
+            "gp2": {
+              "drives": [
+                {
+                  "device": "/dev/sdf",
+                  "size": "1024G"
+                },
+                {
+                  "device": "/dev/sdg",
+                  "size": "1024G"
+                }
+              ]
+            },
+            "st1": {
+              "drives": [
+                {
+                  "device": "/dev/sdf",
+                  "size": "2048G"
+                }
+              ]
+            }
           }
+
         }
       }
     },
@@ -966,6 +1121,160 @@
             }
           },
           "r5.metal": {
+            "gp2": {
+              "drives": [
+                {
+                  "device": "/dev/sdf",
+                  "size": "2048G"
+                },
+                {
+                  "device": "/dev/sdg",
+                  "size": "2048G"
+                }
+              ]
+            },
+            "st1": {
+              "drives": [
+                {
+                  "device": "/dev/sdf",
+                  "size": "4096G"
+                }
+              ]
+            }
+          },
+          "r5b.2xlarge": {
+            "gp2": {
+              "drives": [
+                {
+                  "device": "/dev/sdf",
+                  "size": "512G"
+                },
+                {
+                  "device": "/dev/sdg",
+                  "size": "512G"
+                }
+              ]
+            },
+            "st1": {
+              "drives": [
+                {
+                  "device": "/dev/sdf",
+                  "size": "1024G"
+                }
+              ]
+            }
+          },
+          "r5b.4xlarge": {
+            "gp2": {
+              "drives": [
+                {
+                  "device": "/dev/sdf",
+                  "size": "512G"
+                },
+                {
+                  "device": "/dev/sdg",
+                  "size": "512G"
+                }
+              ]
+            },
+            "st1": {
+              "drives": [
+                {
+                  "device": "/dev/sdf",
+                  "size": "1024G"
+                }
+              ]
+            }
+          },
+          "r5b.8xlarge": {
+            "gp2": {
+              "drives": [
+                {
+                  "device": "/dev/sdf",
+                  "size": "512G"
+                },
+                {
+                  "device": "/dev/sdg",
+                  "size": "512G"
+                }
+              ]
+            },
+            "st1": {
+              "drives": [
+                {
+                  "device": "/dev/sdf",
+                  "size": "1024G"
+                }
+              ]
+            }
+          },
+          "r5b.12xlarge": {
+            "gp2": {
+              "drives": [
+                {
+                  "device": "/dev/sdf",
+                  "size": "1024G"
+                },
+                {
+                  "device": "/dev/sdg",
+                  "size": "1024G"
+                }
+              ]
+            },
+            "st1": {
+              "drives": [
+                {
+                  "device": "/dev/sdf",
+                  "size": "2048G"
+                }
+              ]
+            }
+          },
+          "r5b.16xlarge": {
+            "gp2": {
+              "drives": [
+                {
+                  "device": "/dev/sdf",
+                  "size": "512G"
+                },
+                {
+                  "device": "/dev/sdg",
+                  "size": "512G"
+                }
+              ]
+            },
+            "st1": {
+              "drives": [
+                {
+                  "device": "/dev/sdf",
+                  "size": "1024G"
+                }
+              ]
+            }
+          },
+          "r5b.24xlarge": {
+            "gp2": {
+              "drives": [
+                {
+                  "device": "/dev/sdf",
+                  "size": "2048G"
+                },
+                {
+                  "device": "/dev/sdg",
+                  "size": "2048G"
+                }
+              ]
+            },
+            "st1": {
+              "drives": [
+                {
+                  "device": "/dev/sdf",
+                  "size": "4096G"
+                }
+              ]
+            }
+          },
+          "r5b.metal": {
             "gp2": {
               "drives": [
                 {
@@ -1411,6 +1720,160 @@
                 }
               ]
             }
+          },
+          "r5b.2xlarge": {
+            "gp2": {
+              "drives": [
+                {
+                  "device": "/dev/sdf",
+                  "size": "768G"
+                },
+                {
+                  "device": "/dev/sdg",
+                  "size": "768G"
+                }
+              ]
+            },
+            "st1": {
+              "drives": [
+                {
+                  "device": "/dev/sdf",
+                  "size": "1536G"
+                }
+              ]
+            }
+          },
+          "r5b.4xlarge": {
+            "gp2": {
+              "drives": [
+                {
+                  "device": "/dev/sdf",
+                  "size": "768G"
+                },
+                {
+                  "device": "/dev/sdg",
+                  "size": "768G"
+                }
+              ]
+            },
+            "st1": {
+              "drives": [
+                {
+                  "device": "/dev/sdf",
+                  "size": "1536G"
+                }
+              ]
+            }
+          },
+          "r5b.8xlarge": {
+            "gp2": {
+              "drives": [
+                {
+                  "device": "/dev/sdf",
+                  "size": "512G"
+                },
+                {
+                  "device": "/dev/sdg",
+                  "size": "512G"
+                }
+              ]
+            },
+            "st1": {
+              "drives": [
+                {
+                  "device": "/dev/sdf",
+                  "size": "1024G"
+                }
+              ]
+            }
+          },
+          "r5b.12xlarge": {
+            "gp2": {
+              "drives": [
+                {
+                  "device": "/dev/sdf",
+                  "size": "1536G"
+                },
+                {
+                  "device": "/dev/sdg",
+                  "size": "1536G"
+                }
+              ]
+            },
+            "st1": {
+              "drives": [
+                {
+                  "device": "/dev/sdf",
+                  "size": "3072G"
+                }
+              ]
+            }
+          },
+          "r5b.16xlarge": {
+            "gp2": {
+              "drives": [
+                {
+                  "device": "/dev/sdf",
+                  "size": "512G"
+                },
+                {
+                  "device": "/dev/sdg",
+                  "size": "512G"
+                }
+              ]
+            },
+            "st1": {
+              "drives": [
+                {
+                  "device": "/dev/sdf",
+                  "size": "1024G"
+                }
+              ]
+            }
+          },
+          "r5b.24xlarge": {
+            "gp2": {
+              "drives": [
+                {
+                  "device": "/dev/sdf",
+                  "size": "3072G"
+                },
+                {
+                  "device": "/dev/sdg",
+                  "size": "3072G"
+                }
+              ]
+            },
+            "st1": {
+              "drives": [
+                {
+                  "device": "/dev/sdf",
+                  "size": "6144G"
+                }
+              ]
+            }
+          },
+          "r5b.metal": {
+            "gp2": {
+              "drives": [
+                {
+                  "device": "/dev/sdf",
+                  "size": "3072G"
+                },
+                {
+                  "device": "/dev/sdg",
+                  "size": "3072G"
+                }
+              ]
+            },
+            "st1": {
+              "drives": [
+                {
+                  "device": "/dev/sdf",
+                  "size": "6144G"
+                }
+              ]
+            }
           }
         }
       }
@@ -1836,6 +2299,160 @@
                 }
               ]
             }
+          },
+          "r5b.2xlarge": {
+            "gp2": {
+              "drives": [
+                {
+                  "device": "/dev/sdf",
+                  "size": "1024G"
+                },
+                {
+                  "device": "/dev/sdg",
+                  "size": "1024G"
+                }
+              ]
+            },
+            "st1": {
+              "drives": [
+                {
+                  "device": "/dev/sdf",
+                  "size": "2048G"
+                }
+              ]
+            }
+          },
+          "r5b.4xlarge": {
+            "gp2": {
+              "drives": [
+                {
+                  "device": "/dev/sdf",
+                  "size": "1024G"
+                },
+                {
+                  "device": "/dev/sdg",
+                  "size": "1024G"
+                }
+              ]
+            },
+            "st1": {
+              "drives": [
+                {
+                  "device": "/dev/sdf",
+                  "size": "2048G"
+                }
+              ]
+            }
+          },
+          "r5b.8xlarge": {
+            "gp2": {
+              "drives": [
+                {
+                  "device": "/dev/sdf",
+                  "size": "512G"
+                },
+                {
+                  "device": "/dev/sdg",
+                  "size": "512G"
+                }
+              ]
+            },
+            "st1": {
+              "drives": [
+                {
+                  "device": "/dev/sdf",
+                  "size": "1024G"
+                }
+              ]
+            }
+          },
+          "r5b.12xlarge": {
+            "gp2": {
+              "drives": [
+                {
+                  "device": "/dev/sdf",
+                  "size": "2048G"
+                },
+                {
+                  "device": "/dev/sdg",
+                  "size": "2048G"
+                }
+              ]
+            },
+            "st1": {
+              "drives": [
+                {
+                  "device": "/dev/sdf",
+                  "size": "4096G"
+                }
+              ]
+            }
+          },
+          "r5b.16xlarge": {
+            "gp2": {
+              "drives": [
+                {
+                  "device": "/dev/sdf",
+                  "size": "512G"
+                },
+                {
+                  "device": "/dev/sdg",
+                  "size": "512G"
+                }
+              ]
+            },
+            "st1": {
+              "drives": [
+                {
+                  "device": "/dev/sdf",
+                  "size": "1024G"
+                }
+              ]
+            }
+          },
+          "r5b.24xlarge": {
+            "gp2": {
+              "drives": [
+                {
+                  "device": "/dev/sdf",
+                  "size": "4096G"
+                },
+                {
+                  "device": "/dev/sdg",
+                  "size": "4096G"
+                }
+              ]
+            },
+            "st1": {
+              "drives": [
+                {
+                  "device": "/dev/sdf",
+                  "size": "8192G"
+                }
+              ]
+            }
+          },
+          "r5b.metal": {
+            "gp2": {
+              "drives": [
+                {
+                  "device": "/dev/sdf",
+                  "size": "4096G"
+                },
+                {
+                  "device": "/dev/sdg",
+                  "size": "4096G"
+                }
+              ]
+            },
+            "st1": {
+              "drives": [
+                {
+                  "device": "/dev/sdf",
+                  "size": "8192G"
+                }
+              ]
+            }
           }
         }
       }
@@ -2241,6 +2858,160 @@
             }
           },
           "r5.metal": {
+            "gp2": {
+              "drives": [
+                {
+                  "device": "/dev/sdf",
+                  "size": "5120G"
+                },
+                {
+                  "device": "/dev/sdg",
+                  "size": "5120G"
+                }
+              ]
+            },
+            "st1": {
+              "drives": [
+                {
+                  "device": "/dev/sdf",
+                  "size": "10240G"
+                }
+              ]
+            }
+          },
+          "r5b.2xlarge": {
+            "gp2": {
+              "drives": [
+                {
+                  "device": "/dev/sdf",
+                  "size": "1280G"
+                },
+                {
+                  "device": "/dev/sdg",
+                  "size": "1280G"
+                }
+              ]
+            },
+            "st1": {
+              "drives": [
+                {
+                  "device": "/dev/sdf",
+                  "size": "2560G"
+                }
+              ]
+            }
+          },
+          "r5b.4xlarge": {
+            "gp2": {
+              "drives": [
+                {
+                  "device": "/dev/sdf",
+                  "size": "1280G"
+                },
+                {
+                  "device": "/dev/sdg",
+                  "size": "1280G"
+                }
+              ]
+            },
+            "st1": {
+              "drives": [
+                {
+                  "device": "/dev/sdf",
+                  "size": "2560G"
+                }
+              ]
+            }
+          },
+          "r5b.8xlarge": {
+            "gp2": {
+              "drives": [
+                {
+                  "device": "/dev/sdf",
+                  "size": "512G"
+                },
+                {
+                  "device": "/dev/sdg",
+                  "size": "512G"
+                }
+              ]
+            },
+            "st1": {
+              "drives": [
+                {
+                  "device": "/dev/sdf",
+                  "size": "1024G"
+                }
+              ]
+            }
+          },
+          "r5b.12xlarge": {
+            "gp2": {
+              "drives": [
+                {
+                  "device": "/dev/sdf",
+                  "size": "2560G"
+                },
+                {
+                  "device": "/dev/sdg",
+                  "size": "2560G"
+                }
+              ]
+            },
+            "st1": {
+              "drives": [
+                {
+                  "device": "/dev/sdf",
+                  "size": "5120G"
+                }
+              ]
+            }
+          },
+          "r5b.16xlarge": {
+            "gp2": {
+              "drives": [
+                {
+                  "device": "/dev/sdf",
+                  "size": "512G"
+                },
+                {
+                  "device": "/dev/sdg",
+                  "size": "512G"
+                }
+              ]
+            },
+            "st1": {
+              "drives": [
+                {
+                  "device": "/dev/sdf",
+                  "size": "1024G"
+                }
+              ]
+            }
+          },
+          "r5b.24xlarge": {
+            "gp2": {
+              "drives": [
+                {
+                  "device": "/dev/sdf",
+                  "size": "5120G"
+                },
+                {
+                  "device": "/dev/sdg",
+                  "size": "5120G"
+                }
+              ]
+            },
+            "st1": {
+              "drives": [
+                {
+                  "device": "/dev/sdf",
+                  "size": "10240G"
+                }
+              ]
+            }
+          },
+          "r5b.metal": {
             "gp2": {
               "drives": [
                 {
@@ -4108,7 +4879,323 @@
           ],
           "volume_group": "vghanadata"
         }
+      },
+      "r5b.2xlarge": {
+        "gp2": {
+          "drives": [
+            {
+              "device": "/dev/sdb",
+              "size": "225G"
+            },
+            {
+              "device": "/dev/sdc",
+              "size": "225G"
+            },
+            {
+              "device": "/dev/sdd",
+              "size": "225G"
+            }
+          ],
+          "stride": 256,
+          "stripe": [
+            {
+              "drive": "/hana/data",
+              "logical_volume": "lvhanadata",
+              "size": "585G"
+            }
+          ],
+          "volume_group": "vghanadata"
+        },
+        "io1": {
+          "drives": [
+            {
+              "device": "/dev/sdb",
+              "piops": 2000,
+              "size": "300G"
+            }
+          ],
+          "stride": 256,
+          "stripe": [
+            {
+              "drive": "/hana/data",
+              "logical_volume": "lvhanadata",
+              "size": "292G"
+            }
+          ],
+          "volume_group": "vghanadata"
+        }
+      },
+      "r5b.4xlarge": {
+        "gp2": {
+          "drives": [
+            {
+              "device": "/dev/sdb",
+              "size": "225G"
+            },
+            {
+              "device": "/dev/sdc",
+              "size": "225G"
+            },
+            {
+              "device": "/dev/sdd",
+              "size": "225G"
+            }
+          ],
+          "stride": 256,
+          "stripe": [
+            {
+              "drive": "/hana/data",
+              "logical_volume": "lvhanadata",
+              "size": "585G"
+            }
+          ],
+          "volume_group": "vghanadata"
+        },
+        "io1": {
+          "drives": [
+            {
+              "device": "/dev/sdb",
+              "piops": 2000,
+              "size": "300G"
+            }
+          ],
+          "stride": 256,
+          "stripe": [
+            {
+              "drive": "/hana/data",
+              "logical_volume": "lvhanadata",
+              "size": "292G"
+            }
+          ],
+          "volume_group": "vghanadata"
+        }
+      },
+      "r5b.8xlarge": {
+        "gp2": {
+          "drives": [
+            {
+              "device": "/dev/sdb",
+              "size": "225G"
+            },
+            {
+              "device": "/dev/sdc",
+              "size": "225G"
+            },
+            {
+              "device": "/dev/sdd",
+              "size": "225G"
+            }
+          ],
+          "stride": 256,
+          "stripe": [
+            {
+              "drive": "/hana/data",
+              "logical_volume": "lvhanadata",
+              "size": "674G"
+            }
+          ],
+          "volume_group": "vghanadata"
+        },
+        "io1": {
+          "drives": [
+            {
+              "device": "/dev/sdb",
+              "piops": 7500,
+              "size": "300G"
+            }
+          ],
+          "stride": 256,
+          "stripe": [
+            {
+              "drive": "/hana/data",
+              "logical_volume": "lvhanadata",
+              "size": "299G"
+            }
+          ],
+          "volume_group": "vghanadata"
+        }
+      },
+      "r5b.12xlarge": {
+        "gp2": {
+          "drives": [
+            {
+              "device": "/dev/sdb",
+              "size": "225G"
+            },
+            {
+              "device": "/dev/sdc",
+              "size": "225G"
+            },
+            {
+              "device": "/dev/sdd",
+              "size": "225G"
+            }
+          ],
+          "stride": 256,
+          "stripe": [
+            {
+              "drive": "/hana/data",
+              "logical_volume": "lvhanadata",
+              "size": "585G"
+            }
+          ],
+          "volume_group": "vghanadata"
+        },
+        "io1": {
+          "drives": [
+            {
+              "device": "/dev/sdb",
+              "piops": 7500,
+              "size": "600G"
+            }
+          ],
+          "stride": 256,
+          "stripe": [
+            {
+              "drive": "/hana/data",
+              "logical_volume": "lvhanadata",
+              "size": "585G"
+            }
+          ],
+          "volume_group": "vghanadata"
+        }
+      },
+      "r5b.16xlarge": {
+        "gp2": {
+          "drives": [
+            {
+              "device": "/dev/sdb",
+              "size": "225G"
+            },
+            {
+              "device": "/dev/sdc",
+              "size": "225G"
+            },
+            {
+              "device": "/dev/sdd",
+              "size": "225G"
+            }
+          ],
+          "stride": 256,
+          "stripe": [
+            {
+              "drive": "/hana/data",
+              "logical_volume": "lvhanadata",
+              "size": "674G"
+            }
+          ],
+          "volume_group": "vghanadata"
+        },
+        "io1": {
+          "drives": [
+            {
+              "device": "/dev/sdb",
+              "piops": 7500,
+              "size": "600G"
+            }
+          ],
+          "stride": 256,
+          "stripe": [
+            {
+              "drive": "/hana/data",
+              "logical_volume": "lvhanadata",
+              "size": "599G"
+            }
+          ],
+          "volume_group": "vghanadata"
+        }
+      },
+      "r5b.24xlarge": {
+        "gp2": {
+          "drives": [
+            {
+              "device": "/dev/sdb",
+              "size": "400G"
+            },
+            {
+              "device": "/dev/sdc",
+              "size": "400G"
+            },
+            {
+              "device": "/dev/sdd",
+              "size": "400G"
+            }
+          ],
+          "stride": 256,
+          "stripe": [
+            {
+              "drive": "/hana/data",
+              "logical_volume": "lvhanadata",
+              "size": "1175G"
+            }
+          ],
+          "volume_group": "vghanadata"
+        },
+        "io1": {
+          "drives": [
+            {
+              "device": "/dev/sdb",
+              "piops": 7500,
+              "size": "1200G"
+            }
+          ],
+          "stride": 256,
+          "stripe": [
+            {
+              "drive": "/hana/data",
+              "logical_volume": "lvhanadata",
+              "size": "1175G"
+            }
+          ],
+          "volume_group": "vghanadata"
+        }
+      },
+      "r5b.metal": {
+        "gp2": {
+          "drives": [
+            {
+              "device": "/dev/sdb",
+              "size": "400G"
+            },
+            {
+              "device": "/dev/sdc",
+              "size": "400G"
+            },
+            {
+              "device": "/dev/sdd",
+              "size": "400G"
+            }
+          ],
+          "stride": 256,
+          "stripe": [
+            {
+              "drive": "/hana/data",
+              "logical_volume": "lvhanadata",
+              "size": "1175G"
+            }
+          ],
+          "volume_group": "vghanadata"
+        },
+        "io1": {
+          "drives": [
+            {
+              "device": "/dev/sdb",
+              "piops": 7500,
+              "size": "1200G"
+            }
+          ],
+          "stride": 256,
+          "stripe": [
+            {
+              "drive": "/hana/data",
+              "logical_volume": "lvhanadata",
+              "size": "1175G"
+            }
+          ],
+          "volume_group": "vghanadata"
+        }
       }
+
     }
   },
   "hana_log": {
@@ -5587,7 +6674,295 @@
           ],
           "volume_group": "vghanalog"
         }
+      },
+      "r5b.2xlarge": {
+        "gp2": {
+          "drives": [
+            {
+              "device": "/dev/sdh",
+              "size": "175G"
+            },
+            {
+              "device": "/dev/sdi",
+              "size": "175G"
+            }
+          ],
+          "stride": 256,
+          "stripe": [
+            {
+              "drive": "/hana/log",
+              "logical_volume": "lvhanalog",
+              "size": "325G"
+            }
+          ],
+          "volume_group": "vghanalog"
+        },
+        "io1": {
+          "drives": [
+            {
+              "device": "/dev/sdh",
+              "piops": 1000,
+              "size": "260G"
+            }
+          ],
+          "stride": 256,
+          "stripe": [
+            {
+              "drive": "/hana/log",
+              "logical_volume": "lvhanalog",
+              "size": "256G"
+            }
+          ],
+          "volume_group": "vghanalog"
+        }
+      },
+      "r5b.4xlarge": {
+        "gp2": {
+          "drives": [
+            {
+              "device": "/dev/sdh",
+              "size": "175G"
+            },
+            {
+              "device": "/dev/sdi",
+              "size": "175G"
+            }
+          ],
+          "stride": 256,
+          "stripe": [
+            {
+              "drive": "/hana/log",
+              "logical_volume": "lvhanalog",
+              "size": "325G"
+            }
+          ],
+          "volume_group": "vghanalog"
+        },
+        "io1": {
+          "drives": [
+            {
+              "device": "/dev/sdh",
+              "piops": 1000,
+              "size": "260G"
+            }
+          ],
+          "stride": 256,
+          "stripe": [
+            {
+              "drive": "/hana/log",
+              "logical_volume": "lvhanalog",
+              "size": "256G"
+            }
+          ],
+          "volume_group": "vghanalog"
+        }
+      },
+      "r5b.8xlarge": {
+        "gp2": {
+          "drives": [
+            {
+              "device": "/dev/sdh",
+              "size": "300G"
+            },
+            {
+              "device": "/dev/sdi",
+              "size": "300G"
+            }
+          ],
+          "stride": 256,
+          "stripe": [
+            {
+              "drive": "/hana/log",
+              "logical_volume": "lvhanalog",
+              "size": "599G"
+            }
+          ],
+          "volume_group": "vghanalog"
+        },
+        "io1": {
+          "drives": [
+            {
+              "device": "/dev/sdh",
+              "piops": 2000,
+              "size": "260G"
+            }
+          ],
+          "stride": 256,
+          "stripe": [
+            {
+              "drive": "/hana/log",
+              "logical_volume": "lvhanalog",
+              "size": "259G"
+            }
+          ],
+          "volume_group": "vghanalog"
+        }
+      },
+      "r5b.12xlarge": {
+        "gp2": {
+          "drives": [
+            {
+              "device": "/dev/sdh",
+              "size": "300G"
+            },
+            {
+              "device": "/dev/sdi",
+              "size": "300G"
+            }
+          ],
+          "stride": 256,
+          "stripe": [
+            {
+              "drive": "/hana/log",
+              "logical_volume": "lvhanalog",
+              "size": "512G"
+            }
+          ],
+          "volume_group": "vghanalog"
+        },
+        "io1": {
+          "drives": [
+            {
+              "device": "/dev/sdh",
+              "piops": 2000,
+              "size": "260G"
+            }
+          ],
+          "stride": 256,
+          "stripe": [
+            {
+              "drive": "/hana/log",
+              "logical_volume": "lvhanalog",
+              "size": "256G"
+            }
+          ],
+          "volume_group": "vghanalog"
+        }
+      },
+      "r5b.16xlarge": {
+        "gp2": {
+          "drives": [
+            {
+              "device": "/dev/sdh",
+              "size": "300G"
+            },
+            {
+              "device": "/dev/sdi",
+              "size": "300G"
+            }
+          ],
+          "stride": 256,
+          "stripe": [
+            {
+              "drive": "/hana/log",
+              "logical_volume": "lvhanalog",
+              "size": "599G"
+            }
+          ],
+          "volume_group": "vghanalog"
+        },
+        "io1": {
+          "drives": [
+            {
+              "device": "/dev/sdh",
+              "piops": 2000,
+              "size": "260G"
+            }
+          ],
+          "stride": 256,
+          "stripe": [
+            {
+              "drive": "/hana/log",
+              "logical_volume": "lvhanalog",
+              "size": "259G"
+            }
+          ],
+          "volume_group": "vghanalog"
+        }
+      },
+      "r5b.24xlarge": {
+        "gp2": {
+          "drives": [
+            {
+              "device": "/dev/sdh",
+              "size": "300G"
+            },
+            {
+              "device": "/dev/sdi",
+              "size": "300G"
+            }
+          ],
+          "stride": 256,
+          "stripe": [
+            {
+              "drive": "/hana/log",
+              "logical_volume": "lvhanalog",
+              "size": "512G"
+            }
+          ],
+          "volume_group": "vghanalog"
+        },
+        "io1": {
+          "drives": [
+            {
+              "device": "/dev/sdh",
+              "piops": 2000,
+              "size": "525G"
+            }
+          ],
+          "stride": 256,
+          "stripe": [
+            {
+              "drive": "/hana/log",
+              "logical_volume": "lvhanalog",
+              "size": "512G"
+            }
+          ],
+          "volume_group": "vghanalog"
+        }
+      },
+      "r5b.metal": {
+        "gp2": {
+          "drives": [
+            {
+              "device": "/dev/sdh",
+              "size": "300G"
+            },
+            {
+              "device": "/dev/sdi",
+              "size": "300G"
+            }
+          ],
+          "stride": 256,
+          "stripe": [
+            {
+              "drive": "/hana/log",
+              "logical_volume": "lvhanalog",
+              "size": "512G"
+            }
+          ],
+          "volume_group": "vghanalog"
+        },
+        "io1": {
+          "drives": [
+            {
+              "device": "/dev/sdh",
+              "piops": 2000,
+              "size": "525G"
+            }
+          ],
+          "stride": 256,
+          "stripe": [
+            {
+              "drive": "/hana/log",
+              "logical_volume": "lvhanalog",
+              "size": "512G"
+            }
+          ],
+          "volume_group": "vghanalog"
+        }
       }
+
     }
   },
   "shared": {
@@ -5833,6 +7208,76 @@
         }
       },
       "r5.metal": {
+        "gp2": {
+          "drives": [
+            {
+              "device": "/dev/sde",
+              "size": "1024G"
+            }
+          ]
+        }
+      },
+      "r5b.2xlarge": {
+        "gp2": {
+          "drives": [
+            {
+              "device": "/dev/sde",
+              "size": "300G"
+            }
+          ]
+        }
+      },
+      "r5b.4xlarge": {
+        "gp2": {
+          "drives": [
+            {
+              "device": "/dev/sde",
+              "size": "300G"
+            }
+          ]
+        }
+      },
+      "r5b.8xlarge": {
+        "gp2": {
+          "drives": [
+            {
+              "device": "/dev/sde",
+              "size": "300G"
+            }
+          ]
+        }
+      },
+      "r5b.12xlarge": {
+        "gp2": {
+          "drives": [
+            {
+              "device": "/dev/sde",
+              "size": "512G"
+            }
+          ]
+        }
+      },
+      "r5b.16xlarge": {
+        "gp2": {
+          "drives": [
+            {
+              "device": "/dev/sde",
+              "size": "512G"
+            }
+          ]
+        }
+      },
+      "r5b.24xlarge": {
+        "gp2": {
+          "drives": [
+            {
+              "device": "/dev/sde",
+              "size": "1024G"
+            }
+          ]
+        }
+      },
+      "r5b.metal": {
         "gp2": {
           "drives": [
             {
@@ -6095,6 +7540,76 @@
             }
           ]
         }
+      },
+      "r5b.2xlarge": {
+        "gp2": {
+          "drives": [
+            {
+              "device": "/dev/sds",
+              "size": "50G"
+            }
+          ]
+        }
+      },
+      "r5b.4xlarge": {
+        "gp2": {
+          "drives": [
+            {
+              "device": "/dev/sds",
+              "size": "50G"
+            }
+          ]
+        }
+      },
+      "r5b.8xlarge": {
+        "gp2": {
+          "drives": [
+            {
+              "device": "/dev/sds",
+              "size": "50G"
+            }
+          ]
+        }
+      },
+      "r5b.12xlarge": {
+        "gp2": {
+          "drives": [
+            {
+              "device": "/dev/sds",
+              "size": "50G"
+            }
+          ]
+        }
+      },
+      "r5b.16xlarge": {
+        "gp2": {
+          "drives": [
+            {
+              "device": "/dev/sds",
+              "size": "50G"
+            }
+          ]
+        }
+      },
+      "r5b.24xlarge": {
+        "gp2": {
+          "drives": [
+            {
+              "device": "/dev/sds",
+              "size": "50G"
+            }
+          ]
+        }
+      },
+      "r5b.metal": {
+        "gp2": {
+          "drives": [
+            {
+              "device": "/dev/sds",
+              "size": "50G"
+            }
+          ]
+        }
       }
     },
     "worker": {
@@ -6279,6 +7794,76 @@
         }
       },
       "r5.metal": {
+        "gp2": {
+          "drives": [
+            {
+              "device": "/dev/sds",
+              "size": "50G"
+            }
+          ]
+        }
+      },
+      "r5b.2xlarge": {
+        "gp2": {
+          "drives": [
+            {
+              "device": "/dev/sds",
+              "size": "50G"
+            }
+          ]
+        }
+      },
+      "r5b.4xlarge": {
+        "gp2": {
+          "drives": [
+            {
+              "device": "/dev/sds",
+              "size": "50G"
+            }
+          ]
+        }
+      },
+      "r5b.8xlarge": {
+        "gp2": {
+          "drives": [
+            {
+              "device": "/dev/sds",
+              "size": "50G"
+            }
+          ]
+        }
+      },
+      "r5b.12xlarge": {
+        "gp2": {
+          "drives": [
+            {
+              "device": "/dev/sds",
+              "size": "50G"
+            }
+          ]
+        }
+      },
+      "r5b.16xlarge": {
+        "gp2": {
+          "drives": [
+            {
+              "device": "/dev/sds",
+              "size": "50G"
+            }
+          ]
+        }
+      },
+      "r5b.24xlarge": {
+        "gp2": {
+          "drives": [
+            {
+              "device": "/dev/sds",
+              "size": "50G"
+            }
+          ]
+        }
+      },
+      "r5b.metal": {
         "gp2": {
           "drives": [
             {

--- a/templates/SAP-HANA-BaseNodes.template
+++ b/templates/SAP-HANA-BaseNodes.template
@@ -211,6 +211,13 @@ Parameters:
       - r5.16xlarge
       - r5.24xlarge
       - r5.metal
+      - r5b.2xlarge
+      - r5b.4xlarge
+      - r5b.8xlarge
+      - r5b.12xlarge
+      - r5b.16xlarge
+      - r5b.24xlarge
+      - r5b.metal
       - x1.16xlarge
       - x1.32xlarge
       - x1e.xlarge

--- a/templates/SAP-HANA-BaseNodes.template
+++ b/templates/SAP-HANA-BaseNodes.template
@@ -1518,32 +1518,86 @@ Resources:
                   - s3:GetObject
                   - s3:ListBucket
                   - s3:GetBucketLocation
-                  - ec2:Describe*
-                  - ec2:ModifyInstanceAttribute
-                  - ec2:AttachVolume
-                  - ec2:CreateTags
-                  - ec2:CreateVolume
-                Resource: '*'
+                Resource: !Join
+                  - ''
+                  - - "arn:aws:s3:::"
+                    - !Select
+                      - "2"
+                      - !Split
+                        - "/"
+                        - !Ref "HANAInstallMedia"
+              
+              - Effect: Allow
+                Action: ec2:ModifyInstanceAttribute
+                Resource: "arn:aws:ec2:*:*:instance/*"
+                Condition:
+                  StringEquals: 
+                    "ec2:ResourceTag/aws:cloudformation:stack-name": !Ref AWS::StackName
+              
+              - Effect: Allow
+                Action: ec2:CreateTags
+                Resource: 
+                  - "arn:aws:ec2:*:*:volume/*"
+                  - "arn:aws:ec2:*:*:instance/*"
+
+              - Effect: Allow
+                Action: ec2:AttachVolume
+                Resource:
+                  - "arn:aws:ec2:*:*:volume/*"
+                  - "arn:aws:ec2:*:*:instance/*"
+                Condition:
+                  StringLike: 
+                    "ec2:ResourceTag/SAPHANAQuickStart": !Ref AWS::StackId
+
+              - Effect: Allow
+                Action: ec2:CreateVolume
+                Resource: "*"
+                Condition:
+                  ForAllValues:StringEquals: 
+                    "aws:TagKeys": "SAPHANAQuickStart"
+                    
+              - Effect: Allow
+                Action:
+                  - ec2:DescribeVolumes
+                  - ec2:DescribeVolumeStatus
+                  - ec2:DescribeInstances
+                Resource: "*"
+                
               - Effect: Allow
                 Action: cloudwatch:GetMetricStatistics
                 Resource: '*'
+              
+              - Effect: Allow
+                Action: cloudformation:DescribeStacks
+                Resource: !Join
+                  - ''
+                  - - "arn:aws:cloudformation:"
+                    - !Ref "AWS::Region"
+                    - ':'
+                    - !Ref "AWS::AccountId"
+                    - ':stack/'
+                    - !Ref "AWS::StackName"
+                    - '/*'
+
               - Effect: Allow
                 Action:
-                  - sqs:*
-                  - dynamodb:*
+                  - dynamodb:CreateTable
+                  - dynamodb:DeleteTable
+                  - dynamodb:UpdateItem
+                  - dynamodb:DescribeTable
                   - dynamodb:Scan
                   - dynamodb:Query
                   - dynamodb:GetItem
                   - dynamodb:BatchGetItem
                   - dynamodb:UpdateTable
-                  - cloudformation:DescribeStacks
-                  - cloudformation:DescribeStackEvents
-                  - cloudformation:DescribeStackResource
-                  - cloudformation:DescribeStackResources
-                  - cloudformation:GetTemplate
-                  - cloudformation:List*
-                Resource:
-                  - '*'
+                Resource: !Join
+                  - ''
+                  - - "arn:aws:dynamodb:"
+                    - !Ref "AWS::Region"
+                    - ':'
+                    - !Ref "AWS::AccountId"
+                    - ':table/HANAMonitor__'
+                    - !Ref "AWS::StackName"
   HANAIAMProfile:
     Type: AWS::IAM::InstanceProfile
     Properties:
@@ -1573,93 +1627,11 @@ Resources:
             Action:
               - sts:AssumeRole
       Path: /
-      Policies:
-        - PolicyName: root
-          PolicyDocument:
-            Version: '2012-10-17'
-            Statement:
-              - Effect: Allow
-                Action:
-                  - s3:*
-                  - ec2:Describe*
-                  - ec2:AttachNetworkInterface
-                  - ec2:AttachVolume
-                  - ec2:CreateTags
-                  - ec2:CreateVolume
-                  - ec2:DeleteVolume
-                  - ec2:RunInstances
-                  - ec2:StartInstances
-                  - ec2:CreateSecurityGroup
-                  - ec2:CreatePlacementGroup
-                  - ec2:CreateSnapshot
-                Resource: '*'
-              - Action:
-                  - sqs:*
-                Effect: Allow
-                Resource: '*'
-              - Effect: Allow
-                Action:
-                  - cloudformation:CreateStack
-                  - cloudformation:DeleteStack
-                  - cloudformation:DescribeStack
-                  - cloudformation:EstimateTemplateCost
-                  - cloudformation:ValidateTemplate
-                  - cloudformation:DescribeStackEvents
-                  - cloudformation:DescribeStackResource
-                  - cloudformation:DescribeStackResources
-                  - cloudformation:DescribeStacks
-                Resource:
-                  - '*'
-              - Effect: Allow
-                Action:
-                  - iam:CreateRole
-                Resource:
-                  - '*'
-              - Effect: Allow
-                Action:
-                  - iam:PutRolePolicy
-                Resource:
-                  - '*'
-              - Effect: Allow
-                Action:
-                  - iam:CreateInstanceProfile
-                Resource:
-                  - '*'
-              - Effect: Allow
-                Action:
-                  - iam:AddRoleToInstanceProfile
-                Resource:
-                  - '*'
-              - Effect: Allow
-                Action:
-                  - iam:PassRole
-                Resource:
-                  - '*'
-              - Effect: Allow
-                Action:
-                  - ec2:RevokeSecurityGroupEgress
-                Resource:
-                  - '*'
-              - Effect: Allow
-                Action:
-                  - ec2:AuthorizeSecurityGroupEgress
-                Resource:
-                  - '*'
-              - Effect: Allow
-                Action:
-                  - ec2:AuthorizeSecurityGroupIngress
-                Resource:
-                  - '*'
-              - Effect: Allow
-                Action:
-                  - ec2:CreateNetworkInterface
-                Resource:
-                  - '*'
-              - Effect: Allow
-                Action:
-                  - ec2:ModifyNetworkInterfaceAttribute
-                Resource:
-                  - '*'
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AmazonEC2RoleforSSM
+        - arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess
+        - arn:aws:iam::aws:policy/AmazonEC2ReadOnlyAccess
+        
   RDPProfile:
     Condition: NeedWindowsInstance
     Type: AWS::IAM::InstanceProfile
@@ -1719,6 +1691,8 @@ Resources:
       Tags:
         - Key: Name
           Value: SAP RDP Instance (Public Subnet)
+        - Key: SAPHANAQuickStart
+          Value: !Ref 'AWS::StackId'
       InstanceType: !Ref 'RDPInstanceType'
       UserData: !Base64
         Fn::Join:
@@ -1764,6 +1738,8 @@ Resources:
       Tags:
         - Key: Name
           Value: SAP HANA Master
+        - Key: SAPHANAQuickStart
+          Value: !Ref AWS::StackId
       UserData: !Base64
         Fn::Join:
           - ''
@@ -2021,6 +1997,8 @@ Resources:
       Tags:
         - Key: Name
           Value: SAP HANA Worker 1
+        - Key: SAPHANAQuickStart
+          Value: !Ref AWS::StackId
       UserData: !Base64
         Fn::Join:
           - ''
@@ -2265,6 +2243,8 @@ Resources:
       Tags:
         - Key: Name
           Value: SAP HANA Worker 2
+        - Key: SAPHANAQuickStart
+          Value: !Ref AWS::StackId
       UserData: !Base64
         Fn::Join:
           - ''
@@ -2494,6 +2474,8 @@ Resources:
       Tags:
         - Key: Name
           Value: SAP HANA Worker 3
+        - Key: SAPHANAQuickStart
+          Value: !Ref AWS::StackId
       UserData: !Base64
         Fn::Join:
           - ''
@@ -2738,6 +2720,8 @@ Resources:
       Tags:
         - Key: Name
           Value: SAP HANA Worker 4
+        - Key: SAPHANAQuickStart
+          Value: !Ref AWS::StackId
       UserData: !Base64
         Fn::Join:
           - ''
@@ -2982,6 +2966,8 @@ Resources:
       Tags:
         - Key: Name
           Value: SAP HANA Worker 5
+        - Key: SAPHANAQuickStart
+          Value: !Ref AWS::StackId
       UserData: !Base64
         Fn::Join:
           - ''

--- a/templates/SAP-HANA-NewVPC.template
+++ b/templates/SAP-HANA-NewVPC.template
@@ -168,6 +168,13 @@ Parameters:
       - r5.16xlarge
       - r5.24xlarge
       - r5.metal
+      - r5b.2xlarge
+      - r5b.4xlarge
+      - r5b.8xlarge
+      - r5b.12xlarge
+      - r5b.16xlarge
+      - r5b.24xlarge
+      - r5b.metal
       - x1.16xlarge
       - x1.32xlarge
       - x1e.xlarge


### PR DESCRIPTION
*Description of changes:*
- Adding support for R5b instance types
- Re-worked all IAM policies attached to SAP HANA and RDP nodes


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
