### PR TITLE
Applied a connection timeout to reduce the time to timeout, r option …

### DIFF
--- a/scripts/create-attach-volume.sh
+++ b/scripts/create-attach-volume.sh
@@ -178,7 +178,8 @@ while [  $COUNTER -lt ${VOL_COUNT} ]; do
 					--size ${VOL_SIZE} \
 					--volume-type ${VOL_TYPE} --iops ${VOL_PIOPS} \
 					--tag-specification ResourceType=volume,Tags=[\{Key=SAPHANAQuickStart,Value=${MyStackId}\}] \
-					| ${JQ_COMMAND} '.VolumeId')
+					--cli-connect-timeout 15 \
+					| ${JQ_COMMAND} -r '.VolumeId')
 	else
 		volumeid=$(aws ec2 create-volume \
 					--region ${AWS_DEFAULT_REGION} \
@@ -186,9 +187,10 @@ while [  $COUNTER -lt ${VOL_COUNT} ]; do
 					--size ${VOL_SIZE} \
 					--volume-type ${VOL_TYPE} \
 					--tag-specification ResourceType=volume,Tags=[\{Key=SAPHANAQuickStart,Value=${MyStackId}\}] \
-					| ${JQ_COMMAND} '.VolumeId')
+					--cli-connect-timeout 15 \
+					| ${JQ_COMMAND} -r '.VolumeId')
 	fi
-	volumeid=$(echo ${volumeid} | sed 's/^"\(.*\)"$/\1/')
+	[ -z "${volumeid}" ] && log "The volume ID is empty. Check the reachability to EC2 endpoint and options ${AWS_DEFAULT_REGION}, ${AWS_DEFAULT_AVAILABILITY_ZONE}, ${VOL_SIZE}, ${VOL_TYPE} and ${MyStackId}."
 	log "Creating new volume ${volumeid}. Waiting for create"
 	wait_for_volume_create ${volumeid}
 


### PR DESCRIPTION
…for jq to remove double quotation instead of sed and new debug message when volume id is empty.

*Issue #, if available:*

The lack of check or debug message for the reachability issue to EC2 endpoint.

*Description of changes:*

Added debug message when volume id is empty, which means aws ec2 create-volume was failed. In addition to that, I replaced the code with an "r" option for jq instead of sed just to remove the double quotations and added connection timeout in AWS CLI to avoid spending long time to find out timeout like 15 min.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
